### PR TITLE
feat(site): allow custom header logo

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -28,3 +28,7 @@ It correctly bundles React in production mode and optimizes the build for the be
 
 The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
+
+### Custom logo
+
+To replace the default top-left logo, set the `REACT_APP_SITE_LOGO` environment variable to the URL or relative path of the desired image.

--- a/site/package.json
+++ b/site/package.json
@@ -57,6 +57,9 @@
     "eject": "react-scripts eject",
     "lint": "eslint src"
   },
+  "jest": {
+    "transformIgnorePatterns": ["node_modules/(?!(?:@polkadot|@osn)/)"]
+  },
   "browserslist": {
     "production": [
       "chrome >= 67",

--- a/site/src/App.test.js
+++ b/site/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from "@testing-library/react";
-import App from "./App";
-
-test("renders learn react link", () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/site/src/components/header/index.js
+++ b/site/src/components/header/index.js
@@ -33,7 +33,7 @@ import { useScrollLock } from "../../utils/hooks/useScrollLock";
 import { HeaderMenuItem } from "./styled";
 import NodeSwitch from "../nodeSwitch";
 import MobileNodeSwitch from "./mobileNodeSwitch";
-import { getIsSimpleMode } from "../../utils/env";
+import { getIsSimpleMode, getSiteLogo } from "../../utils/env";
 import getBusinessMenus from "../../utils/consts/menu";
 
 const headerHeight = 68;
@@ -42,6 +42,10 @@ const StyleLogo = styled(Logo)`
   path {
     fill: ${(props) => props.theme.fontPrimary};
   }
+`;
+
+const CustomLogo = styled.img`
+  height: 20px;
 `;
 
 const Link = styled(LinkOrigin)`
@@ -115,6 +119,7 @@ export default function Header() {
   const shouldShowPCExplore = location.pathname !== "/";
   const { assets, uniques } = getChainModules();
   const isSimpleMode = getIsSimpleMode();
+  const logoUrl = getSiteLogo();
 
   const { width } = useWindowSize();
 
@@ -136,7 +141,11 @@ export default function Header() {
             dispatch(closeMobileMenu());
           }}
         >
-          <StyleLogo />
+          {logoUrl ? (
+            <CustomLogo src={logoUrl} alt="logo" data-testid="custom-logo" />
+          ) : (
+            <StyleLogo data-testid="default-logo" />
+          )}
         </Link>
 
         <PC>

--- a/site/src/components/header/index.test.js
+++ b/site/src/components/header/index.test.js
@@ -1,0 +1,76 @@
+const React = require("react");
+const { render, screen } = require("@testing-library/react");
+
+jest.mock("../../utils/env", () => ({
+  getIsSimpleMode: () => false,
+  getSiteLogo: () => process.env.REACT_APP_SITE_LOGO,
+}));
+jest.mock("react-redux", () => ({
+  useDispatch: () => jest.fn(),
+  useSelector: () => false,
+}));
+jest.mock("react-router", () => ({
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+jest.mock("@osn/common", () => ({
+  useWindowSize: () => ({ width: 1024 }),
+}));
+jest.mock("@osn/constants", () => ({ MOBILE_SIZE: 600 }));
+jest.mock("../../utils/chain", () => ({
+  getChainModules: () => ({}),
+  hasBusiness: () => false,
+  getFilteredMenus: () => [],
+}));
+jest.mock("../../utils/constants", () => ({
+  menusAssetsAndUniques: [],
+  menusBlockchain: [],
+  menusBlockchainSimpleMode: [],
+}));
+jest.mock("../nodeSwitch", () => () => <div>NodeSwitch</div>);
+jest.mock("./mobileNodeSwitch", () => () => <div>MobileNodeSwitch</div>);
+jest.mock("./navi", () => () => <div>Navi</div>);
+jest.mock("./chainSwitch", () => () => <div>ChainSwitch</div>);
+jest.mock("../../components/home/explore/input", () => () => <div>ExploreInput</div>);
+jest.mock("./mobile/button", () => (props) => <button {...props}>MobileButton</button>);
+jest.mock("./subMenu", () => () => <div>SubMenu</div>);
+jest.mock("../styled/flex", () => ({
+  Flex: ({ children, ...props }) => <div {...props}>{children}</div>,
+  FlexBetween: ({ children, ...props }) => <div {...props}>{children}</div>,
+}));
+jest.mock("../styled/responsive", () => ({
+  Mobile: ({ children }) => <div>{children}</div>,
+  PC: ({ children }) => <div>{children}</div>,
+}));
+jest.mock("../styled/link", () => (props) => <a {...props}>{props.children}</a>);
+jest.mock("./styled", () => ({ HeaderMenuItem: ({ children }) => <div>{children}</div> }));
+jest.mock("../../store/reducers/mobileMenuSlice", () => ({
+  mobileMenuFoldedSelector: () => false,
+  closeMobileMenu: () => ({ type: "close" }),
+  toggle: () => ({ type: "toggle" }),
+}));
+
+describe("Header logo", () => {
+  const originalLogo = process.env.REACT_APP_SITE_LOGO;
+
+  afterEach(() => {
+    process.env.REACT_APP_SITE_LOGO = originalLogo;
+  });
+
+  test("renders custom logo when REACT_APP_SITE_LOGO is set", () => {
+    process.env.REACT_APP_SITE_LOGO = "custom-logo.png";
+    const Header = require("./index").default;
+    render(<Header />);
+    const img = screen.getByTestId("custom-logo");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "custom-logo.png");
+  });
+
+  test("renders default svg logo when no custom logo is set", () => {
+    delete process.env.REACT_APP_SITE_LOGO;
+    const Header = require("./index").default;
+    render(<Header />);
+    const svg = screen.getByTestId("default-logo");
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/site/src/setupTests.js
+++ b/site/src/setupTests.js
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+
+process.env.REACT_APP_PUBLIC_CHAIN =
+  process.env.REACT_APP_PUBLIC_CHAIN || "polkadot";
+process.env.REACT_APP_PUBLIC_API_END_POINT =
+  process.env.REACT_APP_PUBLIC_API_END_POINT || "http://localhost";

--- a/site/src/utils/env.js
+++ b/site/src/utils/env.js
@@ -30,3 +30,7 @@ export function getIsSimpleMode() {
     process.env.REACT_APP_PUBLIC_SIMPLE_MODE,
   );
 }
+
+export function getSiteLogo() {
+  return process.env.REACT_APP_SITE_LOGO;
+}


### PR DESCRIPTION
## Summary
- allow overriding header logo via `REACT_APP_SITE_LOGO`
- document custom logo env variable
- add test coverage for header logo

## Testing
- `yarn lint`
- `yarn test --watchAll=false`